### PR TITLE
Enable specifying frame IDs for the odom->base_link transform

### DIFF
--- a/p2os_driver/include/p2os_driver/p2os.h
+++ b/p2os_driver/include/p2os_driver/p2os.h
@@ -152,6 +152,8 @@ class P2OSNode
     SIP* sippacket;
     std::string psos_serial_port;
     std::string psos_tcp_host;
+    std::string odom_frame_id;
+    std::string base_link_frame_id;
     int         psos_fd;
     bool        psos_use_tcp;
     int         psos_tcp_port;

--- a/p2os_driver/include/p2os_driver/sip.h
+++ b/p2os_driver/include/p2os_driver/sip.h
@@ -60,7 +60,7 @@ class SIP
   public:
     // these values are returned in every standard SIP
     bool lwstall, rwstall;
-		unsigned char  motors_enabled, sonar_flag;
+	unsigned char  motors_enabled, sonar_flag;
     unsigned char status, battery, sonarreadings, analog, digin, digout;
     unsigned short ptu, compass, timer, rawxpos;
     unsigned short rawypos, frontbumpers, rearbumpers;
@@ -68,6 +68,8 @@ class SIP
     unsigned short *sonars;
     int xpos, ypos;
     int x_offset,y_offset,angle_offset;
+    std::string odom_frame_id;
+    std::string base_link_frame_id;
 
     // these values are returned in a CMUcam serial string extended SIP
     // (in host byte-order)

--- a/p2os_driver/src/p2os.cc
+++ b/p2os_driver/src/p2os.cc
@@ -44,6 +44,8 @@ P2OSNode::P2OSNode( ros::NodeHandle nh ) :
 
   // Use sonar
   ros::NodeHandle n_private("~");
+  n_private.param(std::string("odom_frame_id"), odom_frame_id,std::string("odom"));
+  n_private.param(std::string("base_link_frame_id"), base_link_frame_id,std::string("base_link"));
   n_private.param("use_sonar", use_sonar_, false);
 
   // read in config options
@@ -509,6 +511,8 @@ int P2OSNode::Setup()
   if(!sippacket)
   {
     sippacket = new SIP(param_idx);
+    sippacket->odom_frame_id = odom_frame_id;
+    sippacket->base_link_frame_id = base_link_frame_id;
   }
 /*
   sippacket->x_offset = 0;

--- a/p2os_driver/src/sip.cc
+++ b/p2os_driver/src/sip.cc
@@ -64,8 +64,8 @@ void SIP::FillStandard(ros_p2os_data_t* data)
   }
 
   // timestamps get set in the p2os::StandardSIPPutData fcn
-  data->position.header.frame_id = "odom";
-  data->position.child_frame_id = "base_link";
+  data->position.header.frame_id = odom_frame_id;
+  data->position.child_frame_id = base_link_frame_id;
 
   data->position.pose.pose.position.x = px;
   data->position.pose.pose.position.y = py;


### PR DESCRIPTION
So far, the frame IDs have been hardcoded. We have several use-cases in which we need to specify the frame IDs manually.
