### PR TITLE
Reduce CMake version to 2.8

### DIFF
--- a/p2os_driver/CMakeLists.txt
+++ b/p2os_driver/CMakeLists.txt
@@ -1,12 +1,9 @@
-cmake_minimum_required(VERSION 3.9.5)
+cmake_minimum_required(VERSION 2.8)
 project(p2os_driver)
 
 # Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra)
+  add_compile_options(-Wall -Wextra -std=c++14)
 endif()
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
Reduces the CMake version to version 2.8 for indigo. @tfoote thanks for letting me know!


connects to #60 