### PR TITLE
Two fixes for Melodic.

### DIFF
--- a/p2os_driver/CMakeLists.txt
+++ b/p2os_driver/CMakeLists.txt
@@ -43,7 +43,6 @@ add_executable(p2os_driver
 )
 
 target_link_libraries(p2os_driver ${catkin_LIBRARIES})
-add_dependencies(p2os_driver p2os_msgs_gencpp)
 
 ## Mark executables and/or libraries for installation
 install(TARGETS p2os_driver

--- a/p2os_teleop/CMakeLists.txt
+++ b/p2os_teleop/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.9.5)
 project(p2os_teleop)
 
 find_package(catkin REQUIRED COMPONENTS geometry_msgs std_msgs sensor_msgs tf)


### PR DESCRIPTION
In p2os_driver, the p2os_msgs_gencpp doesn't exist (and, as
far as I can tell, never existed).  It worked up until recently
because older versions of CMake would complain but not fail,
while more recent cmake versions actually fail.  Just remove
the dependency.

The second fix is a cosmetic issue, where CMake would spew a
bunch of warnings on the command line.  Increase the version
to 3.9.5 to match other CMakeLists.txt and to get rid of the
warnings.

@allenh1 This should fix the current problems on the ROS buildfarm [here](http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__p2os_driver__ubuntu_bionic_amd64__binary/6/consoleFull).